### PR TITLE
add config file component

### DIFF
--- a/source/proxy-dll/component/config.cpp
+++ b/source/proxy-dll/component/config.cpp
@@ -1,0 +1,133 @@
+#include <std_include.hpp>
+#include "config.hpp"
+#include "loader/component_loader.hpp"
+#include <filesystem> 
+
+namespace config
+{
+    struct defaultconfig
+    {
+        std::string description;
+        std::string default_value;
+    };
+
+    static std::map<const std::string, const std::string> configs{};
+    static std::map<const std::string, defaultconfig> default_configs{};
+
+    void load_configs()
+    {
+        static bool loaded = false;
+
+        if (loaded) {
+            return;
+        }
+        loaded = true;
+
+        std::ifstream stream;
+        stream.open("project-bo4.cfg", std::fstream::in);
+
+        if (stream.fail())
+        {
+            // no config?
+            return;
+        }
+
+        std::string line;
+
+        while (std::getline(stream, line))
+        {
+            if (line.empty() || line[0] == '#')
+            {
+                continue; // ignore comment
+            }
+
+            size_t idx = line.find('=');
+
+
+            if (idx == std::string::npos)
+            {
+                continue; // no data
+            }
+
+            const std::string key = line.substr(0, idx);
+            const std::string val = line.substr(idx + 1, line.length());
+
+            configs.insert(std::pair(key, val));
+        }
+
+        stream.close();
+    }
+    void sync_configs()
+    {
+        if (std::filesystem::exists("project-bo4.cfg")) return; // no need to recreate it
+
+        std::ofstream stream;
+        stream.open("project-bo4.cfg", std::fstream::out);
+
+        if (stream.fail())
+        {
+            logger::write(logger::LOG_TYPE_WARN, "Error while syncing config file.");
+            return;
+        }
+
+        for (auto& [key, val] : configs)
+        {
+            if (default_configs.find(key) != default_configs.end())
+            {
+                defaultconfig& d = default_configs.at(key);
+                stream << "# " << d.description << ", default: " << d.default_value << '\n';
+            }
+            stream << key << '=' << val << "\n";
+        }
+
+        stream.close();
+    }
+
+    const std::string& noconfig()
+    {
+        static const std::string no_config = "";
+        return no_config;
+    }
+
+    void register_config_value(const std::string& key, const std::string& default_value, const char* description)
+    {
+        load_configs();
+        defaultconfig& d = default_configs[key];
+        d.default_value = default_value;
+        d.description = description;
+
+        // will insert the data if required
+        if (configs.find(key) == configs.end())
+        {
+            configs.insert(std::pair(key, default_value));
+        }
+    }
+
+    const std::string& get_config_value(const std::string &cfg)
+    {
+        load_configs();
+        if (configs.find(cfg) == configs.end())
+        {
+            return noconfig();
+        }
+        return configs.at(cfg);
+    }
+
+
+    class component final : public component_interface
+    {
+    public:
+
+        void post_unpack() override
+        {
+            sync_configs();
+        }
+
+        int priority() override
+        {
+            return 0;
+        }
+    };
+}
+
+REGISTER_COMPONENT(config::component)

--- a/source/proxy-dll/component/config.cpp
+++ b/source/proxy-dll/component/config.cpp
@@ -72,12 +72,13 @@ namespace config
 
         for (auto& [key, val] : configs)
         {
-            if (default_configs.find(key) != default_configs.end())
+            auto dval = default_configs.find(key);
+            if (dval != default_configs.end())
             {
-                defaultconfig& d = default_configs.at(key);
+                defaultconfig& d = dval->second;
                 stream << "# " << d.description << ", default: " << d.default_value << '\n';
             }
-            stream << key << '=' << val << "\n";
+            stream << key << '=' << val << "\n\n";
         }
 
         stream.close();
@@ -108,7 +109,7 @@ namespace config
         load_configs();
         if (configs.find(cfg) == configs.end())
         {
-            return noconfig();
+            return "";
         }
         return configs.at(cfg);
     }

--- a/source/proxy-dll/component/config.hpp
+++ b/source/proxy-dll/component/config.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <string>
+
+namespace config
+{
+	const std::string& noconfig();
+	void register_config_value(const std::string& key, const std::string& default_value, const char* description);
+	const std::string& get_config_value(const std::string& cfg);
+}

--- a/source/proxy-dll/component/debugging.cpp
+++ b/source/proxy-dll/component/debugging.cpp
@@ -1,4 +1,5 @@
 #include <std_include.hpp>
+#include "component/config.hpp"
 #include "loader/component_loader.hpp"
 #include "definitions/t8_engine.hpp"
 #include "scheduler.hpp"
@@ -6,6 +7,7 @@
 
 namespace debugging
 {
+	static bool should_draw_debugging_info = false;
 	typedef short(__fastcall* UI_Model_GetModelForController_t)(int controllerIndex);
 	UI_Model_GetModelForController_t UI_Model_GetModelForController = (UI_Model_GetModelForController_t)0x143AD0200_g;
 
@@ -119,7 +121,6 @@ namespace debugging
 
 		void draw_debug_info()
 		{
-			static bool should_draw_debugging_info = false;
 			if (GetAsyncKeyState(VK_INSERT) & 0x01) should_draw_debugging_info ^= 1;
 
 			if (!should_draw_debugging_info) return;
@@ -148,6 +149,14 @@ namespace debugging
 class component final : public component_interface
 {
 public:
+	void pre_start() override
+	{
+		config::register_config_value("debug_info", "false", "Draw debugging info");
+
+		const std::string& dcfg = config::get_config_value("debug_info");
+
+		should_draw_debugging_info = dcfg != config::noconfig() && dcfg == "true";
+	}
 	void post_unpack() override
 	{	
 		scheduler::loop(draw_debug_info, scheduler::renderer);

--- a/source/proxy-dll/component/debugging.cpp
+++ b/source/proxy-dll/component/debugging.cpp
@@ -153,9 +153,7 @@ public:
 	{
 		config::register_config_value("debug_info", "false", "Draw debugging info");
 
-		const std::string& dcfg = config::get_config_value("debug_info");
-
-		should_draw_debugging_info = dcfg != config::noconfig() && dcfg == "true";
+		should_draw_debugging_info = config::get_config_value("debug_info") == "true";
 	}
 	void post_unpack() override
 	{	

--- a/source/proxy-dll/component/platform.cpp
+++ b/source/proxy-dll/component/platform.cpp
@@ -7,13 +7,14 @@
 #include <utils/cryptography.hpp>
 #include "WinReg.hpp"
 #include "definitions/t8_engine.hpp"
+#include "component/config.hpp"
 
 namespace platform
 {
 	uint64_t bnet_get_userid()
 	{
 		static uint64_t userid = 0;
-		if (!userid) userid = utils::cryptography::xxh32::compute(utils::identity::get_sys_username());
+		if (!userid) userid = utils::cryptography::xxh32::compute(bnet_get_username());
 
 		return userid;
 	}
@@ -23,7 +24,16 @@ namespace platform
 		static std::string username{};
 		if (username.empty())
 		{
-			username = utils::identity::get_sys_username();
+			std::string cfg = config::get_config_value("username");
+
+			if (cfg == config::noconfig() || cfg == "$system")
+			{
+				username = utils::identity::get_sys_username();
+			}
+			else
+			{
+				username = cfg;
+			}
 		}
 
 		return username.data();
@@ -79,7 +89,7 @@ namespace platform
 	public:
 		void pre_start() override
 		{
-			check_platform_registry();
+			config::register_config_value("username", "$system", "The username used ingame, $system to use your system name");
 		}
 
 		void post_unpack() override


### PR DESCRIPTION
Hello,

I've made this little change, it adds a component to read/create configs from/into a `project-bo4.cfg` file

For now I've only added an option to set the username and display the debug info without using *INSERT*

the default **project-bo4.cfg**
```cfg
# Draw debugging info, default: false
debug_info=false
# The username used ingame, $system to use your system name, default: $system
username=$system
```

It was symply to add a method to set the username, because my Windows' username is a bit ugly IG