### PR TITLE
Reimplement acts gsc debug objects of #48

### DIFF
--- a/source/proxy-dll/component/debugging.cpp
+++ b/source/proxy-dll/component/debugging.cpp
@@ -1,6 +1,7 @@
 #include <std_include.hpp>
 #include "definitions/game.hpp"
 #include "component/scheduler.hpp"
+#include "component/gsc_custom.hpp"
 #include "loader/component_loader.hpp"
 
 #include <utilities/hook.hpp>
@@ -73,6 +74,12 @@ namespace debugging
 
 	void sys_error_stub(uint32_t code, const char* message)
 	{
+		if (code == gsc_custom::linking_error)
+		{
+			gsc_custom::find_linking_issues();
+			return; // converted to runtime error to avoid the crash
+		}
+
 		const char* error_message = runtime_errors::get_error_message(code);
 
 		if (error_message)

--- a/source/proxy-dll/component/gsc_custom.hpp
+++ b/source/proxy-dll/component/gsc_custom.hpp
@@ -3,6 +3,10 @@
 
 namespace gsc_custom
 {
+	constexpr uint32_t linking_error = 1670707254;
+	constexpr uint16_t lazylink_opcode = 0x16;
+	constexpr uint16_t shield_devblock_opcode = 0x21;
+
 	enum gsic_field_type
 	{
 		GSIC_FIELD_DETOUR = 0
@@ -22,8 +26,10 @@ namespace gsc_custom
 	struct gsic_info
 	{
 		bool sync{};
+		bool dev_blocks{};
 		std::vector<gsic_detour> detours{};
 	};
 
 	void sync_gsic(game::scriptInstance_t inst, gsic_info& info);
+	void find_linking_issues();
 }

--- a/source/proxy-dll/component/gsc_funcs.hpp
+++ b/source/proxy-dll/component/gsc_funcs.hpp
@@ -7,6 +7,7 @@ namespace gsc_funcs
 	constexpr auto serious_custom_func_name = "SeriousCustom";
 
 	extern bool enable_dev_func;
+	extern bool enable_dev_blocks;
 
 	uint32_t canon_hash(const char* str);
 	uint32_t canon_hash_pattern(const char* str);

--- a/source/proxy-dll/component/mods.cpp
+++ b/source/proxy-dll/component/mods.cpp
@@ -6,8 +6,9 @@
 #include "command.hpp"
 #include "loader/component_loader.hpp"
 
-#include "definitions/xassets.hpp"
 #include "definitions/game.hpp"
+#include "definitions/xassets.hpp"
+#include "definitions/scripting.hpp"
 
 #include <utilities/io.hpp>
 #include <utilities/hook.hpp>
@@ -22,6 +23,13 @@ namespace mods {
 	std::filesystem::path mod_dir = "project-bo4/mods";
 
 	namespace {
+		template<typename T>
+		inline byte* align_ptr(byte* ptr)
+		{
+			return reinterpret_cast<byte*>((reinterpret_cast<uintptr_t>(ptr) + sizeof(T) - 1) & ~(sizeof(T) - 1));
+		}
+
+
 		struct raw_file
 		{
 			xassets::raw_file_header header{};
@@ -142,6 +150,89 @@ namespace mods {
 				// we need to remove the header to keep the alignment
 				data = data.substr(gsic_header_size, data.length() - gsic_header_size);
 
+				return true;
+			}
+
+			bool load_acts_debug()
+			{
+				if ((data.length() < sizeof(game::GSC_OBJ) + sizeof(game::acts_debug::MAGIC))
+					|| *reinterpret_cast<decltype(game::acts_debug::MAGIC)*>(&data[sizeof(game::GSC_OBJ)]) != game::acts_debug::MAGIC)
+				{
+					return true; // too small to be a debug file
+				}
+				game::acts_debug::GSC_ACTS_DEBUG& dbg = *reinterpret_cast<game::acts_debug::GSC_ACTS_DEBUG*>(data.data() + sizeof(game::GSC_OBJ));
+
+
+				logger::write(logger::LOG_TYPE_DEBUG, "loading acts debug file v%x.%llx", dbg.version, dbg.actsVersion);
+
+				byte* ptr = (byte*)data.data();
+
+				if (dbg.has_feature(game::acts_debug::ADF_STRING))
+				{
+					char* start = data.data();
+					for (uint32_t* strs = dbg.get_strings(ptr); strs != dbg.get_strings_end(ptr); strs++)
+					{
+						const char* val = data.data() + *strs;
+						hashes::add_hash(fnv1a::generate_hash(val), val);
+						hashes::add_hash(gsc_funcs::canon_hash(val), val);
+					}
+				}
+
+				if (dbg.has_feature(game::acts_debug::ADF_DETOUR))
+				{
+					for (game::acts_debug::GSC_ACTS_DETOUR* detours = dbg.get_detours(ptr); detours != dbg.get_detours_end(ptr); detours++)
+					{
+						gsc_custom::gsic_detour& detour = gsic.detours.emplace_back();
+
+						detour.fixup_name = 0;
+						detour.replace_namespace = detours->name_space;
+						detour.replace_function = detours->name;
+						detour.fixup_offset = detours->location;
+						detour.fixup_size = detours->size;
+						detour.target_script = detours->script;
+
+						logger::write(logger::LOG_TYPE_DEBUG, std::format(
+							"read detour : namespace_{:x}<script_{:x}>::function_{:x} / offset=0x{:x}+0x{:x}",
+							detour.replace_namespace, detour.target_script, detour.replace_function,
+							detour.fixup_offset, detour.fixup_size
+						));
+					}
+				}
+
+				if (gsc_funcs::enable_dev_blocks)
+				{
+					if (dbg.has_feature(game::acts_debug::ADF_DEVBLOCK_BEGIN))
+					{
+						if (dbg.devblock_count)
+						{
+							gsic.dev_blocks = true;
+
+							// we need to patch the dev function imports to load them
+
+							game::GSC_OBJ* prime_obj = (game::GSC_OBJ*)data.data();
+
+							game::GSC_IMPORT_ITEM* import_item = prime_obj->get_imports();
+
+							for (size_t i = 0; i < prime_obj->imports_count; i++)
+							{
+								// mark this function for the custom linker
+								if ((import_item->flags & game::GIF_DEV_CALL) != 0)
+								{
+									import_item->flags |= game::GIF_SHIELD_DEV_BLOCK_FUNC;
+								}
+
+								// goto to the next element after the addresses
+								uint32_t* addresses = reinterpret_cast<uint32_t*>(import_item + 1);
+								import_item = reinterpret_cast<game::GSC_IMPORT_ITEM*>(addresses + import_item->num_address);
+							}
+						}
+						for (uint32_t* devblock = dbg.get_devblocks(ptr); devblock != dbg.get_devblocks_end(ptr); devblock++)
+						{
+							byte* base = align_ptr<uint16_t>(ptr + *devblock);
+							*(uint16_t*)base = gsc_custom::shield_devblock_opcode;
+						}
+					}
+				}
 				return true;
 			}
 		};
@@ -427,15 +518,21 @@ namespace mods {
 						return false;
 					}
 
-					if (tmp.gsic.detours.size())
-					{
-						logger::write(logger::LOG_TYPE_DEBUG, std::format("loaded {} detours", tmp.gsic.detours.size()));
-					}
-
 					if (tmp.data.length() < sizeof(game::GSC_OBJ) || *reinterpret_cast<uint64_t*>(tmp.data.data()) != gsc_magic)
 					{
 						logger::write(logger::LOG_TYPE_ERROR, std::format("bad scriptparsetree magic in {} for mod {}", spt_path.string(), mod_name));
 						return false;
+					}
+
+					if (!tmp.load_acts_debug())
+					{
+						logger::write(logger::LOG_TYPE_ERROR, std::format("error when reading ACTS DEBUG header of {} for mod {}", spt_path.string(), mod_name));
+						return false;
+					}
+
+					if (tmp.gsic.detours.size())
+					{
+						logger::write(logger::LOG_TYPE_DEBUG, std::format("loaded {} detours", tmp.gsic.detours.size()));
 					}
 
 					// after this point we assume that the GSC file is well formatted

--- a/source/proxy-dll/definitions/game.hpp
+++ b/source/proxy-dll/definitions/game.hpp
@@ -491,6 +491,7 @@ namespace game
 	// Cmd
 	WEAK symbol<void(int localClientNum, const char* text)> Cbuf_AddText{ 0x143CDE880_g };
 	WEAK symbol<void(int localClientNum, int controllerIndex, const char* buffer)> Cbuf_ExecuteBuffer{ 0x143CDEBE0_g };
+	WEAK symbol<int()> Com_LocalClients_GetPrimary{ 0x142893AF0_g };
 
 	WEAK symbol<void(BO4_AssetRef_t* cmdName, xcommand_t function, cmd_function_t* allocedCmd)> Cmd_AddCommandInternal{ 0x143CDEE80_g };
 	WEAK symbol<void()> Cbuf_AddServerText_f{ 0x143CDE870_g };
@@ -569,6 +570,7 @@ namespace game
 	WEAK symbol<BuiltinFunction(uint32_t canonId, int* type, int* min_args, int* max_args)> Scr_GetFunction{ 0x1433AF840_g };
 	WEAK symbol<void*(uint32_t canonId, int* type, int* min_args, int* max_args)> CScr_GetMethod{ 0x141F13650_g };
 	WEAK symbol<void*(uint32_t canonId, int* type, int* min_args, int* max_args)> Scr_GetMethod{ 0x1433AFC20_g };
+	WEAK symbol<void(game::scriptInstance_t inst, byte* codepos, const char** scriptname, int32_t* sloc, int32_t* crc, int32_t* vm)> Scr_GetGscExportInfo{ 0x142748550_g };
 
 	WEAK symbol<void(uint64_t code, scriptInstance_t inst, char* unused, bool terminal)> ScrVm_Error{ 0x142770330_g };
 	WEAK symbol<BO4_scrVarPub> scrVarPub{ 0x148307880_g };

--- a/source/proxy-dll/definitions/scripting.hpp
+++ b/source/proxy-dll/definitions/scripting.hpp
@@ -34,7 +34,7 @@ namespace game
 		int32_t include_offset;
 		uint16_t string_count;
 		uint16_t exports_count;
-		int32_t start_data;
+		int32_t cseg_offset;
 		int32_t string_offset;
 		int16_t imports_count;
 		uint16_t fixup_count;
@@ -48,7 +48,7 @@ namespace game
 		int32_t script_size;
 		int32_t requires_implements_offset;
 		int32_t ukn50;
-		int32_t data_length;
+		int32_t cseg_size;
 		uint16_t include_count;
 		byte ukn5a;
 		byte requires_implements_count;
@@ -283,4 +283,157 @@ namespace game
 		int refCount;
 		uint32_t groupId;
 	};
+
+	enum GSC_EXPORT_FLAGS : byte
+	{
+		GEF_LINKED = 0x01,
+		GEF_AUTOEXEC = 0x02,
+		GEF_PRIVATE = 0x04,
+		GEF_CLASS_MEMBER = 0x08,
+		GEF_CLASS_DESTRUCTOR = 0x10,
+		GEF_VE = 0x20,
+		GEF_EVENT = 0x40,
+		GEF_CLASS_LINKED = 0x80,
+		GEF_CLASS_VTABLE = 0x86
+	};
+
+	enum GSC_IMPORT_FLAGS : byte
+	{
+		GIF_FUNC_METHOD = 0x1,
+		GIF_FUNCTION = 0x2,
+		GIF_FUNCTION_THREAD = 0x3,
+		GIF_FUNCTION_CHILDTHREAD = 0x4,
+		GIF_METHOD = 0x5,
+		GIF_METHOD_THREAD = 0x6,
+		GIF_METHOD_CHILDTHREAD = 0x7,
+		GIF_CALLTYPE_MASK = 0xF,
+		GIF_DEV_CALL = 0x10,
+		GIF_GET_CALL = 0x20,
+
+		GIF_SHIELD_DEV_BLOCK_FUNC = 0x80,
+	};
+
+	namespace acts_debug
+	{
+		constexpr uint64_t MAGIC = 0x0d0a42444124;
+		constexpr byte CURRENT_VERSION = 0x12;
+
+		enum GSC_ACTS_DEBUG_FEATURES : byte
+		{
+			ADF_STRING = 0x10,
+			ADF_DETOUR = 0x11,
+			ADF_DEVBLOCK_BEGIN = 0x12,
+			ADF_LAZYLINK = 0x12,
+			ADF_CRC_LOC = 0x13,
+			ADF_DEVSTRING = 0x14,
+			ADF_LINES = 0x15,
+			ADF_FILES = 0x15,
+			ADF_FLAGS = 0x15,
+		};
+
+		enum GSC_ACTS_DEBUG_FLAGS : uint32_t
+		{
+			ADFG_OBFUSCATED = 1 << 0,
+			ADFG_DEBUG = 1 << 1,
+			ADFG_CLIENT = 1 << 2,
+			ADFG_PLATFORM_SHIFT = 3,
+			ADFG_PLATFORM_MASK = 0xF << ADFG_PLATFORM_SHIFT,
+		};
+
+		struct GSC_ACTS_DETOUR
+		{
+			uint64_t name_space;
+			uint64_t name;
+			uint64_t script;
+			uint32_t location;
+			uint32_t size;
+		};
+
+		struct GSC_ACTS_LAZYLINK
+		{
+			uint64_t name_space;
+			uint64_t name;
+			uint64_t script;
+			uint32_t num_address;
+		};
+
+		struct GSC_ACTS_DEVSTRING
+		{
+			uint32_t string;
+			uint32_t num_address;
+		};
+
+		struct GSC_ACTS_LINES
+		{
+			uint32_t start;
+			uint32_t end;
+			size_t lineNum;
+		};
+
+		struct GSC_ACTS_FILES
+		{
+			uint32_t filename;
+			size_t lineStart;
+			size_t lineEnd;
+		};
+
+
+		struct GSC_ACTS_DEBUG
+		{
+			byte magic[sizeof(MAGIC)];
+			byte version;
+			uint32_t flags;
+			uint64_t actsVersion;
+			uint32_t strings_offset{};
+			uint32_t strings_count{};
+			uint32_t detour_offset{};
+			uint32_t detour_count{};
+			uint32_t devblock_offset{};
+			uint32_t devblock_count{};
+			uint32_t lazylink_offset{};
+			uint32_t lazylink_count{};
+			uint32_t crc_offset{};
+			uint32_t devstrings_offset{};
+			uint32_t devstrings_count{};
+			uint32_t lines_offset{};
+			uint32_t lines_count{};
+			uint32_t files_offset{};
+			uint32_t files_count{};
+
+			constexpr bool has_feature(GSC_ACTS_DEBUG_FEATURES feature) const
+			{
+				return version >= feature;
+			}
+
+			inline GSC_ACTS_DETOUR* get_detours(byte* start)
+			{
+				return reinterpret_cast<GSC_ACTS_DETOUR*>(start + detour_offset);
+			}
+
+			inline GSC_ACTS_DETOUR* get_detours_end(byte* start)
+			{
+				return get_detours(start) + detour_count;
+			}
+
+			inline uint32_t* get_devblocks(byte* start)
+			{
+				return reinterpret_cast<uint32_t*>(start + devblock_offset);
+			}
+
+			inline uint32_t* get_devblocks_end(byte* start)
+			{
+				return get_devblocks(start) + devblock_count;
+			}
+
+			inline uint32_t* get_strings(byte* start)
+			{
+				return reinterpret_cast<uint32_t*>(start + strings_offset);
+			}
+
+			inline uint32_t* get_strings_end(byte* start)
+			{
+				return get_strings(start) + strings_count;
+			}
+		};
+	}
 }


### PR DESCRIPTION
Mostly the GSC part of #48:


## Find GSC linking errors

Instead of crashing with a spectacular 1670707254 sys error, when a script can't be linked (=loaded at the start of the match) it will go back to the lobby and print the linking errors inside the logs.

## GSC functions

I added 2 functions

- `AddDebugCommand(string cmd)` - Reimplementation of the original command, it's basically a CBuf
- `ShieldHashLookup(hash hash)->string` - Lookup a hash to a string

## Support for ACTS compiler

In [my tools](https://github.com/ate47/atian-cod-tools) I have implemented a GSC compiler for Black Ops 4, it provides the same features as the t8-compiler and some others but implemented differently, so I adapted the mod loader.

It adds:

- detour support - Load GSC detours
- dev block support - Allow to use dev blocks (`/# ... #/`), needs the new config `gsc.dev_blocks`
- debug hashes loading - Load the unhashed strings inside the script (if available)
